### PR TITLE
Add include path to libmad folder

### DIFF
--- a/AUDIO_sample/RX64M/Makefile
+++ b/AUDIO_sample/RX64M/Makefile
@@ -80,7 +80,8 @@ INC_SYS     =   $(LOCAL_PATH)/include
 INC_APP		=	. ../../ ../ \
 				../../FreeRTOS/Source/include \
 				../../FreeRTOS/Source/portable/GCC/RX600v2 \
-				../../RX600/drw2d/inc/tes
+				../../RX600/drw2d/inc/tes \
+				../../libmad
 
 LIB_ROOT	=	../../RX600/drw2d ../../libmad ../../zlib ../../libpng
 

--- a/AUDIO_sample/RX65N/Makefile
+++ b/AUDIO_sample/RX65N/Makefile
@@ -80,7 +80,8 @@ INC_SYS     =   $(LOCAL_PATH)/include
 INC_APP		=	. ../../ ../ \
 				../../FreeRTOS/Source/include \
 				../../FreeRTOS/Source/portable/GCC/RX600v2 \
-				../../RX600/drw2d/inc/tes
+				../../RX600/drw2d/inc/tes \
+				../../libmad
 
 LIB_ROOT	=	../../RX600/drw2d ../../libmad ../../zlib ../../libpng
 

--- a/AUDIO_sample/RX72N/Makefile
+++ b/AUDIO_sample/RX72N/Makefile
@@ -80,7 +80,8 @@ INC_SYS     =   $(LOCAL_PATH)/include
 INC_APP		=	. ../../ ../ \
 				../../FreeRTOS/Source/include \
 				../../FreeRTOS/Source/portable/GCC/RX600v2 \
-				../../RX600/drw2d/inc/tes
+				../../RX600/drw2d/inc/tes \
+				../../libmad
 
 LIB_ROOT	=	../../RX600/drw2d ../../libmad ../../zlib ../../libpng
 

--- a/FreeRTOS_FatFs/RX64M/Makefile
+++ b/FreeRTOS_FatFs/RX64M/Makefile
@@ -77,7 +77,8 @@ INC_SYS     =   $(LOCAL_PATH)/include
 
 INC_APP		=	. ../ ../../ \
 				../../FreeRTOS/Source/include \
-				../../FreeRTOS/Source/portable/GCC/RX600v2
+				../../FreeRTOS/Source/portable/GCC/RX600v2 \
+				../../libmad
 
 LIB_ROOT	=	../../libmad
 

--- a/FreeRTOS_FatFs/RX65N/Makefile
+++ b/FreeRTOS_FatFs/RX65N/Makefile
@@ -79,7 +79,8 @@ INC_SYS     =   $(LOCAL_PATH)/include
 INC_APP		=	. ../ ../../ \
 				../../FreeRTOS/Source/include \
 				../../FreeRTOS/Source/portable/GCC/RX600v2 \
-				../../RX600/drw2d/inc/tes
+				../../RX600/drw2d/inc/tes \
+				../../libmad
 
 LIB_ROOT	=	../../RX600/drw2d \
 				../../libmad


### PR DESCRIPTION
@hirakuni45 はじめましてこんにちは。

RX72N Envision Kit を購入したので、平松さんが公開してくださっているプログラムを試そうとしています。

README.md の記述通りに MSYS2 でビルドを行ったところ `sh all_project_build.sh` を行うと下記のようなエラーが出るので対策を入れてみました。

```
Start project (release):  AUDIO_sample RX64M
In file included from ../../sound/codec_mgr.hpp:14:0,
                 from ../../AUDIO_sample/main.cpp:32:
../../sound/mp3_in.hpp:12:17: fatal error: mad.h: No such file or directory
 #include <mad.h>
                 ^
compilation terminated.
make: *** [Makefile:169: release/AUDIO_sample/main.o] エラー 1
Compile error:  AUDIO_sample RX64M
```
