### PR TITLE
Develop

### DIFF
--- a/SDCARD_sample/README.md
+++ b/SDCARD_sample/README.md
@@ -42,6 +42,7 @@ SD card access, sample program
 |RX64M|Soft SPI|○|
 |RX65N|SDHI|△|
 |RX72N|SDHI|△|
+|RX72T|RSPI|△|
 
 ※RTC is used to record the time when writing a file.   
 ※RX24T can use RTC with I2C connection.   
@@ -150,6 +151,21 @@ For power supply control ICs, general-purpose MOS-FETs were used because of avai
 |PC2|86|DAT3(1)|SELECT||
 |P82|79|-|Power CTRL|active-low|
 |P81|80|-|CardDetect|active-low|
+
+---
+
+### RX72T (RSPIc)
+
+|Port name|LFQFP100|SD pin|SD function|Remarks|
+|---|---|---|---|---|
+|P22(MISO)|67|DAT0(7)|SO|pull-up(22K)|
+|P21(MOSI)|68|CMD(2)|SI|damping-register(22)+pull-up(22K)|
+|P20(SPCK)|69|CLK(5)|SCLK|damping-register(22)+pull-up(22K)|
+|P30|63|DAT3(1)|SELECT|pull-up(22K)|
+|PA2|39|-|Power CTRL|active-high|
+|PB4|30|-|CardDetect|active-low|
+
+※[RX72T_100_PGA_USB board circuit](../RX72T/RX72T_100_PGA_USB)
 
 ---
 
@@ -378,6 +394,19 @@ Write Close: 4 [ms]
 
 Read Open:  1 [ms]
 Read: 1622 KBytes/Sec
+Read Close: 0 [ms]
+```
+
+### SPI Mode RX72T (RSPI)
+
+```
+Lexar 633X 16GB (SDHC) Class10
+Write Open:  200 [ms]
+Write: 151 KBytes/Sec
+Write Close: 17 [ms]
+
+Read Open:  2 [ms]
+Read: 654 KBytes/Sec
 Read Close: 0 [ms]
 ```
 

--- a/SDCARD_sample/READMEja.md
+++ b/SDCARD_sample/READMEja.md
@@ -42,6 +42,8 @@ SD カード・アクセス、サンプルプログラム
 |RX64M|Soft SPI|○|
 |RX65N|SDHI|△|
 |RX72N|SDHI|△|
+|RX72T|RSPI|△|
+
 
 ※RTC はファイル書き込み時の時間を記録する為に利用しています。   
 ※RX24T では、I2C 接続の RTC を利用する事が出来ます。   
@@ -164,6 +166,21 @@ typedef device::PORT<device::PORT6, device::bitpos::B4, 0> SDC_POWER;  ///< 「�
 |PC2|86|DAT3(1)|SELECT||
 |P82|79|-|Power CTRL|active-low|
 |P81|80|-|CardDetect|active-low|
+
+---
+
+### RX72T (RSPIc)
+
+|ピン名|LFQFP100|SD ピン|SD 機能|備考|
+|---|---|---|---|---|
+|P22(MISO)|67|DAT0(7)|SO|pull-up(22K)|
+|P21(MOSI)|68|CMD(2)|SI|damping-register(22)+pull-up(22K)|
+|P20(SPCK)|69|CLK(5)|SCLK|damping-register(22)+pull-up(22K)|
+|P30|63|DAT3(1)|SELECT|pull-up(22K)|
+|PA2|39|-|Power CTRL|active-high|
+|PB4|30|-|CardDetect|active-low|
+
+※[RX72T_100_PGA_USB ボード回路図参照](../RX72T/RX72T_100_PGA_USB)
 
 ---
 
@@ -392,6 +409,19 @@ Write Close: 4 [ms]
 
 Read Open:  1 [ms]
 Read: 1622 KBytes/Sec
+Read Close: 0 [ms]
+```
+
+### SPI モード RX72T (RSPI)
+
+```
+Lexar 633X 16GB (SDHC) Class10
+Write Open:  200 [ms]
+Write: 151 KBytes/Sec
+Write Close: 17 [ms]
+
+Read Open:  2 [ms]
+Read: 654 KBytes/Sec
 Read Close: 0 [ms]
 ```
 

--- a/SDCARD_sample/RX72T/Makefile
+++ b/SDCARD_sample/RX72T/Makefile
@@ -1,0 +1,67 @@
+# -*- tab-width : 4 -*-
+#=======================================================================
+#   @file
+#   @brief  RX72T Makefile
+#   @author 平松邦仁 (hira@rvf-rc45.net)
+#	@copyright	Copyright (C) 2021 Kunihito Hiramatsu @n
+#				Released under the MIT license @n
+#				https://github.com/hirakuni45/RX/blob/master/LICENSE
+#=======================================================================
+TARGET		=	sdcard_sample
+
+DEVICE		=	R5F572TK
+
+RX_DEF		=	SIG_RX72T
+
+FATFS_VER	=	ff14/source
+
+BUILD		=	release
+# BUILD		=	debug
+
+VPATH		=	../../
+
+ASOURCES	=	common/start.s
+
+CSOURCES	=	common/init.c \
+				common/vect.c \
+				common/syscalls.c \
+				$(FATFS_VER)/ff.c \
+				$(FATFS_VER)/ffsystem.c \
+				$(FATFS_VER)/ffunicode.c \
+				common/time.c
+
+PSOURCES	=	SDCARD_sample/main.cpp \
+				common/stdapi.cpp
+
+USER_LIBS	=	supc++
+
+USER_DEFS	=	FAT_FS FAT_FS_NUM=3
+
+INC_APP		=	. ../ ../../
+
+AS_OPT		=
+
+CP_OPT		=	-Wall -Werror \
+				-Wno-unused-variable \
+				-Wno-unused-function \
+				-fno-exceptions
+
+CC_OPT		=	-Wall -Werror \
+				-Wno-unused-variable \
+				-fno-exceptions
+
+ifeq ($(BUILD),debug)
+    CC_OPT += -g -DDEBUG
+    CP_OPT += -g -DDEBUG
+	OPTIMIZE = -O0
+endif
+
+ifeq ($(BUILD),release)
+    CC_OPT += -DNDEBUG
+    CP_OPT += -DNDEBUG
+	OPTIMIZE = -O3
+endif
+
+-include ../../common/makefile
+
+-include $(DEPENDS)

--- a/common/makefile
+++ b/common/makefile
@@ -75,7 +75,7 @@ endif
 
 ifeq ($(RX_DEF),SIG_RX72N)
   LIB_ROOT += ../../RX600/drw2d
-  INC_APP +=  ../../RX600/drw2d/inc/tes 
+  INC_APP +=  ../../RX600/drw2d/inc/tes
   USER_LIBS += drw2d
   RX_CPU = RX72N
   RX_OPT = v3
@@ -96,11 +96,11 @@ TARGET_ISA_TEXT := $(shell rx-elf-gcc --target-help | grep ISA)
 
 # Renesas GNU-RX (8.3.0) compiler 
 ifeq ($(TARGET_ISA_TEXT),)
-  # for gcc-7.5.0 current gcc source build
+  # for plain gcc-7.5.0 current gcc source build
   AS_DEFS		=	-mcpu=rx600
   CC_DEFS		=	-mcpu=rx600 -Wa,-mcpu=rxv2
   CP_DEFS		=	-mcpu=rx600
-else # Renesas GNU-RX gcc 8.3.0
+else # Renesas GNU-RX gcc-8.3.0
   AS_DEFS		=	-misa=$(RX_OPT)
   CC_DEFS		=	-misa=$(RX_OPT)
   CP_DEFS		=	-misa=$(RX_OPT)
@@ -153,7 +153,7 @@ DEPENDS =   $(patsubst %.o,%.d, $(DOBJECTS))
 
 all: $(BUILD) $(TARGET).elf text
 
-$(TARGET).elf: $(OBJECTS) $(LDSCRIPT) Makefile
+$(TARGET).elf: $(OBJECTS) $(LDSCRIPT) Makefile ../../common/makefile
 	$(CC) $(LDFLAGS) $(LIBINCS) -o $@ $(OBJECTS) $(LIBS)
 	$(SIZE) $@
 
@@ -169,13 +169,13 @@ $(BUILD)/%.o : %.cpp
 	mkdir -p $(dir $@); \
 	$(CP) -c $(POPT) $(PFLAGS) $(PINCS) $(CPWARN) -o $@ $<
 
-$(BUILD)/%.d: %.c
+$(BUILD)/%.d: %.c Makefile
 	mkdir -p $(dir $@); \
 	$(CC) -MM -DDEPEND_ESCAPE $(COPT) $(CFLAGS) $(APPINCS) $< \
 	| sed 's/$(notdir $*)\.o:/$(subst /,\/,$(patsubst %.d,%.o,$@) $@):/' > $@ ; \
 	[ -s $@ ] || rm -f $@
 
-$(BUILD)/%.d: %.cpp
+$(BUILD)/%.d: %.cpp Makefile
 	mkdir -p $(dir $@); \
 	$(CP) -MM -DDEPEND_ESCAPE $(POPT) $(PFLAGS) $(APPINCS) $< \
 	| sed 's/$(notdir $*)\.o:/$(subst /,\/,$(patsubst %.d,%.o,$@) $@):/' > $@ ; \
@@ -208,16 +208,6 @@ bin: $(TARGET).bin
 
 %.bin: %.elf
 	$(OBJCOPY) -O binary $< $@
-
-# $(TARGET).opt: $(TARGET).elf
-#ifeq ($(FLAGS),$(FLAGS_CMP))
-#	@echo "eq..."
-#else
-#	@echo $(FLAGS) > $(TARGET).opt
-#	@echo "not eq..."
-#	@echo $(FLAGS)
-#	@echo $(FLAGS_CMP)
-#endif
 
 # Serial Flash write 
 run:

--- a/common/rspi_io.hpp
+++ b/common/rspi_io.hpp
@@ -112,13 +112,15 @@ namespace device {
 			@return 最大速度
 		*/
 		//-----------------------------------------------------------------//
-		uint32_t get_max_speed() const noexcept {
-			uint32_t clk = RSPI::PCLK;
+		uint32_t get_max_speed() const noexcept
+		{
+			// 最大クロックは、PCLK の 1/2
+			uint32_t clk = RSPI::PCLK / 2;
 #ifdef SEEDA
-			while(clk > 20000000) {  // 15MHz
-//			while(clk > 10000000) {  // 7MHz
+			while(clk > 20'000'000) {  // 20MHz
+//			while(clk > 10000000) {  // 10MHz
 #else
-			while(clk > 40000000) {
+			while(clk > 40'000'000) {  // 最大 40MHz にしておく
 #endif
 				clk >>= 1;
 			}


### PR DESCRIPTION
- SDCARD_sample に RX72T を追加。
- FatFs mmc_io クラス、カード検出関係を見直し、修正。
- mmc_io デバッグメッセージ関係の管理を更新。
- 共有 makefile に、Makefile、makefile の更新があった場合に、コンパイルをし直すよう設定。