### PR TITLE
Develop

### DIFF
--- a/RX600/dmac_mgr.hpp
+++ b/RX600/dmac_mgr.hpp
@@ -24,6 +24,7 @@ namespace device {
 	template<class DMAC, class TASK = utils::null_task>
 	class dmac_mgr {
 	public:
+		typedef DMAC value_type;
 
 		static const uint32_t BLOCK_SIZE_MAX = 1024;	///< データ転送最大ブロック数
 

--- a/SDCARD_sample/README.md
+++ b/SDCARD_sample/README.md
@@ -408,6 +408,16 @@ Write Close: 17 [ms]
 Read Open:  2 [ms]
 Read: 654 KBytes/Sec
 Read Close: 0 [ms]
+
+-----------------------------------------
+TOSHIBA 40MB/s 32GB (SDHC) Class10
+Write Open:  0 [ms]
+Write: 122 KBytes/Sec
+Write Close: 40 [ms]
+
+Read Open:  0 [ms]
+Read: 522 KBytes/Sec
+Read Close: 0 [ms]
 ```
 
 Since the test is in units of 512 bytes, I think that it is much faster when running continuously.   

--- a/SDCARD_sample/READMEja.md
+++ b/SDCARD_sample/READMEja.md
@@ -423,6 +423,16 @@ Write Close: 17 [ms]
 Read Open:  2 [ms]
 Read: 654 KBytes/Sec
 Read Close: 0 [ms]
+
+-----------------------------------------
+TOSHIBA 40MB/s 32GB (SDHC) Class10
+Write Open:  0 [ms]
+Write: 122 KBytes/Sec
+Write Close: 40 [ms]
+
+Read Open:  0 [ms]
+Read: 522 KBytes/Sec
+Read Close: 0 [ms]
 ```
 
 テストは５１２バイト単位である為、連続で行う場合、もっと高速だと思います。   

--- a/SDCARD_sample/main.cpp
+++ b/SDCARD_sample/main.cpp
@@ -74,6 +74,7 @@ namespace {
 	typedef device::NULL_PORT SDC_WPRT;  ///< カード書き込み禁止ポート設定
 	typedef fatfs::mmc_io<SDC_SPI, SDC_SELECT, SDC_POWER, SDC_DETECT, SDC_WPRT> SDC;
 	SDC		sdc_(sdc_spi_, 20'000'000);
+
 	typedef device::iica_io<device::RIIC0> I2C;
 	typedef chip::DS3231<I2C> RTC;
 	#define ENABLE_I2C_RTC
@@ -197,6 +198,10 @@ namespace {
 	typedef device::NULL_PORT SDC_WPRT;											///< カード書き込み禁止ポート設定（無効）
 	typedef fatfs::mmc_io<SDC_SPI, SDC_SELECT, SDC_POWER, SDC_DETECT, SDC_WPRT> SDC;
 	SDC		sdc_(sdc_spi_, 20'000'000);
+
+	#define ENABLE_I2C_RTC
+	typedef device::iica_io<device::RIIC0> I2C;
+	typedef chip::DS3231<I2C> RTC;
 #endif
 
 	typedef device::system_io<> SYSTEM_IO;
@@ -331,6 +336,7 @@ namespace {
 			UINT sz = sizeof(buff);
 			if(sz > rs) sz = rs;
 			auto bw = fio.write(buff, sz);
+			LED::P = !LED::P();
 			rs -= bw;
 		}
 		ed = cmt_.get_counter();
@@ -373,6 +379,7 @@ namespace {
 			if(sz > rs) sz = rs;
 			auto s = fin.read(buff, sz);
 			if(s == 0) break;
+			LED::P = !LED::P();
 			rs -= s;
 		}
 		ed = cmt_.get_counter();

--- a/common/intmath.hpp
+++ b/common/intmath.hpp
@@ -204,10 +204,10 @@ static short randTapTables[] = {
 		@param[in]	alp		1 周期のループ数
 	*/
 	//+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++//
-	static void build_sincos(sincos_t& t, int16_t alp)
+	static void build_sincos(sincos_t& t, int32_t alp)
 	{
-		static const uint32_t pai_ = 0xC90FDAA2;	///< 円周率(3.141592654 * 2^30)
-		static const uint32_t pai_shift_ = 30;		///< 円周率、小数点位置
+		static constexpr uint32_t pai_ = 0xC90FDAA2;	///< 円周率(3.141592654 * 2^30)
+		static constexpr uint32_t pai_shift_ = 30;		///< 円周率、小数点位置
 		t.x -= ((static_cast<int64_t>(pai_) * t.y) >> (pai_shift_ - 1)) / alp;
 		t.y += ((static_cast<int64_t>(pai_) * t.x) >> (pai_shift_ - 1)) / alp;
 	}


### PR DESCRIPTION
- SDCARD_sample の Read/Write テストで、ブロック毎に LED を点滅するようにした。
- RX72T で Read/Write 速度の参考値として、TOSHIBA製32GBのSDカードを追加。
- 関数のパラメーターを int16_t から int32_t へ変更。（この仕様で３２ビットCPUでは、int16_t を使う意味は無い）
- dmac_mgr クラスにDMAチャネルの基本型にアクセスする「value_type」を追加。